### PR TITLE
Return as boolean when default is boolean

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -34,6 +34,13 @@ function parse(argv, aliases) {
     find(aliases, function (alias, _default) {
       if (! ~keys.indexOf(key)) return !unknown(key);
       if (~alias.indexOf(key)) alias.forEach(function (key) {
+        if (typeof _default === "boolean" && typeof value === "string") {
+          if (value === 'true') {
+            return map[key] = true;
+          } else if (value === 'false') {
+            return map[key] = false;
+          }
+        }
         return map[key] = typeof _default === "string" && typeof value === "boolean" ? _default : value;
       });
     });

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "babel --optional runtime src -d dist",
     "test": "npm run build && npm run tape | tspec",
     "deploy": "npm run test && git push origin master && npm publish",
-    "tape": "node --harmony --harmony_arrow_functions ./node_modules/tape/bin/tape test/*.js"
+    "tape": "node ./node_modules/tape/bin/tape test/*.js"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -17,9 +17,17 @@ function parse (argv, aliases) {
 
     find(aliases, (alias, _default) => {
       if (!~keys.indexOf(key)) return !unknown(key)
-      if (~alias.indexOf(key)) alias.forEach((key) =>
-        map[key] = typeof _default === "string" && typeof value === "boolean"
-          ? _default : value)
+      if (~alias.indexOf(key)) alias.forEach((key) => {
+        if (typeof _default === "boolean" && typeof value === "string") {
+          if (value === 'true') {
+            return map[key] = true
+          } else if (value === 'false') {
+            return map[key] = false
+          }
+        }
+        return map[key] = typeof _default === "string" && typeof value === "boolean"
+          ? _default : value
+      })
     })
   }
   argv.some((token, index) => {

--- a/test/index.js
+++ b/test/index.js
@@ -80,6 +80,12 @@ test("singles", (t) => {
     foo: "/"
   }, "single w/ value and default ")
 
+  t.deepEqual(parse.call(["-af", "true"], ["f", "foo", {default: false}]), {
+    a: true,
+    f: true,
+    foo: true
+  }, "single w/ value and default is boolean")
+
   t.deepEqual(parse.call(["-af", "/"], ["f", "foo", { default: true }]), {
     a: true,
     f: "/",


### PR DESCRIPTION
If you pass in "false" as the argument to a flag that has a default which is
of type boolean, it should return the boolean `false` not a string called
`'false'`